### PR TITLE
remove unnecessary split of 'guessedWord'

### DIFF
--- a/jotto/src/helpers/index.js
+++ b/jotto/src/helpers/index.js
@@ -6,6 +6,6 @@
  */
 export function getLetterMatchCount(guessedWord, secretWord) {
     const secretLetters = secretWord.split('');
-    const guessedLetterSet = new Set(guessedWord.split(''));
+    const guessedLetterSet = new Set(guessedWord);
     return secretLetters.filter(letter => guessedLetterSet.has(letter)).length;
 };


### PR DESCRIPTION
const guessedLetterSet = new Set(guessedWord); 
guessedLetterSet is the same as with or without split('')